### PR TITLE
Feature : Mark issues stale after 60 days of inactivity

### DIFF
--- a/.github/workflows/mark-stale-issues.yml
+++ b/.github/workflows/mark-stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
         issues: write
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-issue-stale: 60

--- a/.github/workflows/mark-stale-issues.yml
+++ b/.github/workflows/mark-stale-issues.yml
@@ -1,0 +1,18 @@
+name: Mark stale issues
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+        issues: write
+    steps:
+    - uses: actions/stale@v8
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 60
+        stale-issue-label: 'stale'
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. Thank you for your contributions.'

--- a/.github/workflows/mark-stale-issues.yml
+++ b/.github/workflows/mark-stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
         issues: write
     steps:
-    - uses: actions/stale@v8
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-issue-stale: 60


### PR DESCRIPTION
# Pull Request

## Description

- Implemented Github Actions to Automatically mark issues stale after 60 days of inactivity.
- Uses `actions/stale@v8`
- automatically removes stale label, if some activity occurs in the issue
## Related Issue(s)

Closes #21 

## Changes Made

- Added mark-stale-issues.yml

## Screenshots (if applicable)

![image](https://github.com/rcallaby/Emacs-Guide/assets/81290616/644d7477-1c3a-440d-9504-be68d5904fc2)


## Checklist

- [x] I have reviewed the [Contributing Guidelines](CONTRIBUTING.md) for this repository.
- [x] I have followed the coding style and conventions of this project.
- [x] I have added/updated relevant documentation (if necessary).
- [x] The code is tested and all tests pass.
- [x] I have updated the version (if applicable).
- [x] All commit messages are meaningful and follow the established convention.

## Additional Notes

- I tested all this in my Repo -> you can check it out [here](https://github.com/Pushkarm029/GH-Actions).

By submitting this pull request, I confirm that my contribution is made under the terms of the [LICENSE](LICENSE) for this project.
