### PR TITLE
Add feature: Mark pull requests stale after 21 days of inactivity

### DIFF
--- a/.github/workflows/mark-stale-issues.yml
+++ b/.github/workflows/mark-stale-issues.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
         issues: write
+        pull-requests: write  # Grant the action permissions for pull requests
     steps:
     - uses: actions/stale@v8
       with:
@@ -16,3 +17,6 @@ jobs:
         days-before-issue-stale: 60
         stale-issue-label: 'stale'
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. Thank you for your contributions.'
+        days-before-pr-stale: 21
+        stale-pr-label: 'stale'
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has not had activity within 21 days. Thank you for your contributions.'  # Add this line to specify the message for stale PRs


### PR DESCRIPTION
# Pull Request

## Description

I've adapted the workflow for stale issues to also include handling stale pull requests after 21 days.

## Related Issue(s)

Closes #20 

## Changes Made

Updated `mark-stale-issues.yml` to also include marking stale pull requests.

- added the following lines to `mark-stale-issues.yml`:
```yml
days-before-pr-stale: 21
stale-pr-label: 'stale'
stale-pr-message: 'This pull request has been automatically marked as stale because it has not had activity within 21 days. Thank you for your contributions.'
 ```

## Checklist

- [x] I have reviewed the [Contributing Guidelines](CONTRIBUTING.md) for this repository.
- [x] I have followed the coding style and conventions of this project.
- [x] I have added/updated relevant documentation (if necessary).
- [x] The code is tested and all tests pass.
- [x] I have updated the version (if applicable).
- [x] All commit messages are meaningful and follow the established convention.

## Additional Notes

I thought it might be simpler to leave the file called `mark-stale-issues.yml` but I could see how this can cause some confusion. I think renaming the file to `mark-stale.yml` might be better, and renaming the workflow name to `Mark Stale` as well. Let me know if you'd like me to do this. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [LICENSE](LICENSE) for this project.
