### PR TITLE
foxed the broken links

### DIFF
--- a/Lessons/Part-09-Doom-Emacs/doomemacs.md
+++ b/Lessons/Part-09-Doom-Emacs/doomemacs.md
@@ -14,7 +14,7 @@ Doom Emacs is a highly extensible and pre-configured Emacs framework that aims t
    ```
 
 3. **Install Dependencies**:
-   Depending on your system, you may need to install additional dependencies. Refer to the [official Doom Emacs documentation](https://github.com/hlissner/doom-emacs/blob/develop/docs/getting_started.org#install) for detailed instructions.
+   Depending on your system, you may need to install additional dependencies. Refer to the [official Doom Emacs documentation](https://github.com/doomemacs/doomemacs/blob/master/docs/getting_started.org) for detailed instructions.
 
 4. **Run Doom Emacs**:
    Once the clone is complete, start Emacs by running `emacs` from your terminal.
@@ -60,7 +60,7 @@ Doom Emacs is designed to be highly customizable. Here's how you can start custo
    ```
 
 5. **Other Customizations**:
-   The Doom Emacs documentation provides a wide range of options for customizing your environment. Check the [official documentation](https://github.com/hlissner/doom-emacs/blob/develop/docs/getting_started.org#customizing) for more details.
+   The Doom Emacs documentation provides a wide range of options for customizing your environment. Check the [official documentation](https://github.com/hlissner/doom-emacs/blob/develop/docs/getting_started.org) for more details.
 
 ### Step 4: Updating Doom Emacs
 


### PR DESCRIPTION
# Pull Request

- Fixed the broken links in Doom Emacs lesson

## Description

- There were two broken links that were brought to my attention from the markdown links checker that I fixed.

## Changes Made

- Fixed a documentation link for Doom emacs on how to install it
- Fixed a documentation link for Doom emacs that covered customizing it.

## Checklist

- [ ] I have reviewed the [Contributing Guidelines](https://github.com/rcallaby/Emacs-Guide/blob/main/CONTRIBUTING.md) for this repository.
- [ ] I have added/updated relevant documentation (if necessary).
- [ ] I have updated the version (if applicable).
- [ ] All commit messages are meaningful and follow the established convention.

## Additional Notes

- No additional notes needed at this time.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [LICENSE](https://github.com/rcallaby/Emacs-Guide/blob/main/LICENSE) for this project.
